### PR TITLE
fix: make text visible on htop header and hovered

### DIFF
--- a/themes/latte.conf
+++ b/themes/latte.conf
@@ -48,7 +48,7 @@ mark3_background #209fb5
 # The 16 terminal colors
 
 # black
-color0 #5c5f77
+color0 #e6e9ef
 color8 #6c6f85
 
 # red


### PR DESCRIPTION
Before:
<img width="1366" height="93" alt="Shot-2025-09-22-161949" src="https://github.com/user-attachments/assets/a9966e85-d0e9-46ee-a363-d37983e70024" />

After:
<img width="1366" height="93" alt="Shot-2025-09-22-162010" src="https://github.com/user-attachments/assets/952c33b2-8808-4c7b-bb19-c9d7472bc231" />